### PR TITLE
Add watch video completion option

### DIFF
--- a/language/.en.json
+++ b/language/.en.json
@@ -303,6 +303,10 @@
         {
           "label": "Deactivate sound",
           "description": "Enabling this option will deactivate the video's sound and prevent it from being switched on."
+        },
+        {
+          "label": "Watch video completely to pass",
+          "description": "Require user to watch the entire video before the activity is marked passed."
         }
       ]
     },

--- a/semantics.json
+++ b/semantics.json
@@ -745,7 +745,15 @@
         "label": "Deactivate sound",
         "importance": "low",
         "description": "Enabling this option will deactivate the video's sound and prevent it from being switched on."
-      }
+      },
+      {
+        "name": "watchVideoCompletely",
+        "type": "boolean",
+        "default": false,
+        "label": "Watch video completely to pass",
+        "importance": "low",
+        "description": "Require user to watch the entire video before the activity is marked passed."
+      },
     ]
   },
   {

--- a/src/scripts/endscreen.js
+++ b/src/scripts/endscreen.js
@@ -134,6 +134,10 @@ class Endscreen extends H5P.EventDispatcher {
     if (this.$submitButtonContainer.hasClass(ENDSCREEN_STYLE_BUTTON_HIDDEN)) {
       return;
     }
+    if (this.parent.watchVideoCompletely &&
+        this.parent.getWatchedPercentage() < 100) {
+      return;
+    }
     this.parent.setUserSubmitted(true);
 
     this.$submitButtonContainer.addClass(ENDSCREEN_STYLE_BUTTON_HIDDEN);

--- a/src/scripts/interactive-video.js
+++ b/src/scripts/interactive-video.js
@@ -110,6 +110,7 @@ function InteractiveVideo(params, id, contentData) {
     self.showRewind10 = (params.override.showRewind10 !== undefined ? params.override.showRewind10 : false);
     self.showBookmarksmenuOnLoad = (params.override.showBookmarksmenuOnLoad !== undefined ? params.override.showBookmarksmenuOnLoad : false);
     self.preventSkippingMode = params.override.preventSkippingMode || 'none';
+    self.watchVideoCompletely = params.override.watchVideoCompletely || false;
     self.deactivateSound = params.override.deactivateSound || false;
   }
   // Translated UI text defaults
@@ -918,6 +919,19 @@ InteractiveVideo.prototype.getDuration = function () {
     this.duration = this.video.getDuration();
   }
   return this.duration;
+};
+
+/**
+ * Get how much of the video has been watched in percent.
+ *
+ * @return {number} Percentage watched, 0-100.
+ */
+InteractiveVideo.prototype.getWatchedPercentage = function () {
+  const duration = this.getDuration();
+  if (!duration) {
+    return 0;
+  }
+  return Math.min(100, Math.round(this.maxTimeReached / duration * 100));
 };
 
 /**


### PR DESCRIPTION
## Summary
- add new optional parameter `watchVideoCompletely`
- localize new option in English
- expose `watchVideoCompletely` parameter in JS
- track watched percentage
- block submission if video not watched completely

## Testing
- `npm install`
- `npm test` *(fails: ava not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c54959e78832193b706c725113c1d